### PR TITLE
feat: adding a restrictRotationAngle option

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,16 @@ shapeSimilary(curve1, curve2, { estimationPoints: 200, rotations: 30 });
 shapeSimilary(curve1, curve2, { estimationPoints: 10, rotations: 0 });
 ```
 
+You can also restrict the range of rotations that are checked using the `restrictRotationAngle` option. This option means the shapeSimilarity function will only check rotations within +- `restrictRotationAngle` radians. If you'd like to disable rotation correction entirely, you can set `checkRotations: false`. These are shown below:
+
+```javascript
+// Only check rotations between -0.1 π to 0.1 π
+shapeSimilary(curve1, curve2, { restrictRotationAngle: 0.1 * Math.PI });
+
+// disable rotation correction entirely
+shapeSimilary(curve1, curve2, { checkRotations: false });
+```
+
 ## How it works
 
 Internally, `shapeSimilary` works by first normalizing the curves using [Procrustes analysis](https://en.wikipedia.org/wiki/Procrustes_analysis) and then calculating [Fréchet distance](https://en.wikipedia.org/wiki/Fr%C3%A9chet_distance) between the curves.

--- a/test/shapeSimilarity.test.ts
+++ b/test/shapeSimilarity.test.ts
@@ -46,6 +46,38 @@ describe('shapeSimilarity', () => {
     });
   });
 
+  it('allows restricting the rotation angles that are checked', () => {
+    const curve = [{ x: 0, y: 0 }, { x: 2, y: 4 }, { x: 18, y: -3 }];
+    const withinRangeRotations = [0, -0.2, -0.3, 0.2, 0.3];
+    const outOfRangeRotations = [-0.5, 0.5, Math.PI];
+    translations.forEach(translation => {
+      scales.forEach(scale => {
+        withinRangeRotations.forEach(theta => {
+          const newCurve = translateScaleAndRotate(
+            curve,
+            translation,
+            scale,
+            theta
+          );
+          expect(
+            shapeSimilarity(curve, newCurve, { restrictRotationAngle: 0.3 })
+          ).toBeCloseTo(1);
+        });
+        outOfRangeRotations.forEach(theta => {
+          const newCurve = translateScaleAndRotate(
+            curve,
+            translation,
+            scale,
+            theta
+          );
+          expect(
+            shapeSimilarity(curve, newCurve, { restrictRotationAngle: 0.3 })
+          ).toBeLessThan(0.9);
+        });
+      });
+    });
+  });
+
   it('returns close to 1 if curves have similar shapes', () => {
     const curve1 = [{ x: 0, y: 0 }, { x: 2, y: 4 }, { x: 18, y: -3 }];
     const curve2 = [{ x: 0.3, y: -0.2 }, { x: 2.2, y: 4.5 }, { x: 16, y: -4 }];
@@ -103,6 +135,6 @@ describe('shapeSimilarity', () => {
   it('should be really close to 0 for very dissimilar shapes', () => {
     const curve1 = [{ x: 0, y: 0 }, { x: 1, y: 1 }, { x: 0, y: 0 }];
     const curve2 = [{ x: 0, y: 0 }, { x: 1, y: 1 }];
-    expect(shapeSimilarity(curve1, curve2)).toBeLessThan(0.2);
+    expect(shapeSimilarity(curve1, curve2)).toBeLessThan(0.25);
   });
 });


### PR DESCRIPTION
This PR adds the following options:
- `restrictRotationAngle` restricts the rotations checked to be between this angle, in radians
- `checkRotations` boolean to disable rotation correction entirely

fixes #2 